### PR TITLE
[feat] Makes team member cards link to GitHub

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
       </div>
       
       <div class="team-grid">
+        <a href="https://github.com/devcedrick" target="_blank">
           <div class="team-card">
             <img class="avatar" src="assets/images/jimeno-portrait.png" alt="Ken Cedrick Jimeno's portrait picture">
             <h3 class="member-name">Ken Cedrick Jimeno</h3>
@@ -32,7 +33,9 @@
                 Passionate software architect with expertise in full-stack development and system design. Ken brings <span class="highlight-accent">innovative solutions</span> to complex technical challenges, leading our development initiatives with precision and creativity.
             </p>
           </div>
-          
+        </a>
+        
+        <a href="https://github.com/ClydeZzz16" target="_blank">
           <div class="team-card">
             <img class="avatar" src="assets/images/egmilan-portrait.png" alt="Jean Clyde Egmilan's portrait picture">
             <h3 class="member-name">Jean Clyde Egmilan</h3>
@@ -41,15 +44,18 @@
                 Detail-oriented engineer specializing in software optimization and quality assurance. Jean ensures our products meet the highest standards while implementing <span class="highlight-accent">cutting-edge technologies</span> for enhanced performance.
             </p>
           </div>
-          
+        </a>
+        
+        <a href="https://github.com/devjeyem" target="_blank">
           <div class="team-card">
             <img class="avatar" src="assets/images/pintin-portrait.png" alt="Jm Pintin's portrait picture">
-            <h3 class="member-name">Jm Pintin</h3>
-            <p class="member-role">Systems Engineer</p>
-            <p class="member-description">
-                Strategic thinker focused on scalable system architecture and project coordination. Jm bridges technical excellence with practical implementation, ensuring our solutions are both <span class="highlight-accent">robust and user-friendly</span>.
-            </p>
+              <h3 class="member-name">Jm Pintin</h3>
+              <p class="member-role">Systems Engineer</p>
+              <p class="member-description">
+                  Strategic thinker focused on scalable system architecture and project coordination. Jm bridges technical excellence with practical implementation, ensuring our solutions are both <span class="highlight-accent">robust and user-friendly</span>.
+              </p>
           </div>
+        </a>
       </div>
     </section>
   </main>

--- a/styles/about.css
+++ b/styles/about.css
@@ -32,6 +32,10 @@
   margin-top: 50px;
 }
 
+.team-grid a{
+  text-decoration: none;
+}
+
 .team-card {
   background: white;
   border-radius: 20px;
@@ -41,6 +45,7 @@
   transition: all 0.3s ease;
   position: relative;
   overflow: hidden;
+  cursor: pointer;
 }
 
 .team-card::before {


### PR DESCRIPTION
Enhances user experience by making team member profile cards clickable and linking to their respective GitHub profiles in a new tab.

Also, adjusts styling to remove text decoration from the link and adds a pointer cursor to the team cards to indicate they are clickable.
